### PR TITLE
Fix missing ln in birthday problem approximation formula

### DIFF
--- a/60C05-ApproximatingTheBirthdayProblem.tex
+++ b/60C05-ApproximatingTheBirthdayProblem.tex
@@ -152,7 +152,7 @@ again solve for $k$ to find:
 We also see that if we wish to have an outcome with probability $\varepsilon>0$ of no matches then we can estimate the sample size by:
 \[\varepsilon=p(N,k)\approx e^{-k^2/2N};\qquad k\approx \sqrt{2N \ln \frac{1}{\varepsilon}}.\]
 So the number of samples required to find a match with probability $\varepsilon>0$ is approximately
-\[k=\sqrt{2N\frac{1}{1-\varepsilon}}.\]
+\[k=\sqrt{2N \ln \frac{1}{1-\varepsilon}}.\]
 
 \begin{thebibliography}{9}
 \bibitem{Wikipedia}


### PR DESCRIPTION
Seems like the `ln` was accidentally dropped for 'samples required to find collision' formula, since it's part of the 'samples possible without collision' formula.

This was my second result on Google for 'birthday problem approximation' ;) 